### PR TITLE
AVR speedup

### DIFF
--- a/adc.h
+++ b/adc.h
@@ -33,6 +33,7 @@ public:
     virtual uint32_t getClock(); // return ADC clock in Hz
     virtual uint32_t getSampleRate(); // sampling rate in Hz (actual read speed may vary)
     virtual uint16_t read();          // = analogRead(input)
+    virtual uint16_t readFast();      // = analogRead(input) final part
 };
 
 #ifdef __MK20DX256__

--- a/adc_avr.cpp
+++ b/adc_avr.cpp
@@ -32,6 +32,7 @@ bool ADCInput::init(uint8_t newInput, uint8_t mode){
     input = newInput;
     bits = ADC_BITS;
     pinMode(input, INPUT);
+    ADCInput::setMode(mode);
 }
 
 /*
@@ -42,17 +43,16 @@ uint8_t ADCInput::getModeCount(){
 }
 
 /*
- * Set ADC prescaler.
- * This should accept a clock or time base instead so it's not AVR specific.
+ * Set ADC prescaler
  */
 void ADCInput::setPrescaler(uint8_t mode){
-    // set prescaler
     if (mode < ADCInput::getModeCount()){
         cur_mode = mode;
         uint8_t prescaler = prescalers[mode];
         prescaler & 4 ? sbi(ADCSRA,ADPS2) : cbi(ADCSRA,ADPS2);
         prescaler & 2 ? sbi(ADCSRA,ADPS1) : cbi(ADCSRA,ADPS1);
         prescaler & 1 ? sbi(ADCSRA,ADPS0) : cbi(ADCSRA,ADPS0);
+        sbi(ADCSRA, ADEN);
     }
     delay(10); // allow the ADC to settle
 }

--- a/adc_avr.h
+++ b/adc_avr.h
@@ -33,6 +33,15 @@ public:
     __inline__ uint16_t read(){
         return analogRead(input);
     }
+
+    __inline__ uint16_t readFast(){
+        // this runs just the conversion part of analogRead() without the setup
+        sbi(ADCSRA, ADSC); // ADSC=AD Start Conversion
+        loop_until_bit_is_clear(ADCSRA, ADSC); // Conversion finished
+        uint8_t low  = ADCL;
+        uint8_t high = ADCH;
+        return (high << 8) | low;
+    }
 };
 
 #endif /* ADC_AVR_H_ */

--- a/adc_teensy3.h
+++ b/adc_teensy3.h
@@ -26,6 +26,9 @@ public:
     __inline__ uint16_t read(){
         return analogRead(input);
     }
+    __inline__ uint16_t readFast(){
+        return analogRead(input);
+    }
 };
 
 #endif /* ADC_TEENSY3_ */

--- a/capture.cpp
+++ b/capture.cpp
@@ -21,7 +21,7 @@ int Capture::init(ADCInput adc_in, unsigned samples_in, uint16_t rangemV_in){
 }
 
 /*
- * ADC allowable float for zero-detection (because of unclean ground) [mV]
+ * ADC allowable float for zero-detection (because of unclean ground)
  */
 #define ADC_JITTER 4
 /*
@@ -34,19 +34,21 @@ void Capture::capture(){
     uint16_t v;
     unsigned i = samples;
 
+    adc.read(); // allow the port to be configured (discard result)
+
     dataCur = data;
     /*
      * Attempt to latch on a zero transition
      */
-    for (unsigned j=255; j; j--){
-        v = adc.read();
+    for (unsigned j=1024; j; j--){
+        v = adc.readFast();
         if (v < ADC_JITTER){
             *dataCur++ = v;
             break;
         }
     }
-    for (unsigned j=255; j; j--){
-        v = adc.read();
+    for (unsigned j=1024; j; j--){
+        v = adc.readFast();
         if (v >= ADC_JITTER){
             *dataCur++ = v;
             break;
@@ -56,7 +58,7 @@ void Capture::capture(){
     }
     start = micros();
     for (; i; i--){
-        *dataCur++ = adc.read();
+        *dataCur++ = adc.readFast();
     }
     elapsedus = micros() - start;
 }

--- a/scope.cpp
+++ b/scope.cpp
@@ -98,7 +98,7 @@ void Scope::renderGraph(uint16_t *data, uint16_t rangemV, unsigned samples, int 
         x = map(i, 0, samples-1, minX, maxX);
         y = map(*data, 0, rangemV, minY, maxY);
         if (logicMode && i>0 && abs(lastY-y)>4){
-            if (y-lastY>0){
+            if (y>lastY){
                 display.drawFastVLine(x-1,lastY,y-lastY+1,WHITE);
             } else {
                 display.drawFastVLine(x-1,y,lastY-y+1,WHITE);


### PR DESCRIPTION
Speed up AVR sampling to 190Ksps (from 143K).
Fix square line drawing bug introduced by the move to fixed bit size integer values.
